### PR TITLE
Add GroupAdd option to containers

### DIFF
--- a/server/src/main/js/lib/Schema.js
+++ b/server/src/main/js/lib/Schema.js
@@ -212,6 +212,7 @@ function Schema() {
 
         _copy(viewModel, hostConfig, 'CapAdd');
         _copy(viewModel, hostConfig, 'CapDrop');
+        _copy(viewModel, hostConfig, 'GroupAdd');
 
         if (Utils.notEmpty(viewModel.NetworkMode)) {
             let networkMode = viewModel.NetworkMode;
@@ -409,6 +410,7 @@ function Schema() {
 
         _copy(hostConfig, viewModel, 'CapAdd');
         _copy(hostConfig, viewModel, 'CapDrop');
+        _copy(hostConfig, viewModel, 'GroupAdd');
 
         let networkMode = hostConfig.NetworkMode;
         if (networkMode === "bridge" || networkMode === "host" || networkMode === "none") {
@@ -576,6 +578,7 @@ function Schema() {
         Entrypoint: '<td><input type="text" id="dockerCloudImage_Entrypoint_IDX"/><span class="error" id="dockerCloudImage_Entrypoint_IDX_error"></span></td>',
         CapAdd: '<td><input type="text" id="dockerCloudImage_CapAdd_IDX"/><span class="error" id="dockerCloudImage_CapAdd_IDX_error"></span></td>',
         CapDrop: '<td><input type="text" id="dockerCloudImage_CapDrop_IDX"/><span class="error" id="dockerCloudImage_CapDrop_IDX_error"></span></td>',
+        GroupAdd: '<td><input type="text" id="dockerCloudImage_GroupAdd_IDX"/><span class="error" id="dockerCloudImage_GroupAdd_IDX_error"></span></td>',
         Cmd: '<td><input type="text" id="dockerCloudImage_Cmd_IDX"/></td>',
         Volumes: '<td><input type="text" id="dockerCloudImage_Volumes_IDX_PathOnHost" /></td>\
         <td><input type="text" id="dockerCloudImage_Volumes_IDX_PathInContainer" /><span class="error" id="dockerCloudImage_Volumes_IDX_PathInContainer_error"></span></td>\

--- a/server/src/main/js/lib/image-settings.html
+++ b/server/src/main/js/lib/image-settings.html
@@ -255,6 +255,24 @@
                 </tbody>
             </table>
         </div>
+        <h4>Group add:</h4>
+        <div class="dockerCloudSimpleTables" style="text-align: center;">
+            <table class="settings">
+                <thead>
+                <tr>
+                    <th class="name" style="width: 82%;">
+                        Values&nbsp;<span class="mandatoryAsterix">*</span>
+                        <i class="icon icon16 tc-icon_help_small tooltip"></i>
+                        <span class="tooltiptext">Add additional groups to run as. Equivalent to the
+                            <code>--group-add</code> CLI flag.</span>
+                    </th>
+                    <th class="dockerCloudCtrlCell"></th>
+                </tr>
+                </thead>
+                <tbody id="dockerCloudImage_GroupAdd">
+                </tbody>
+            </table>
+        </div>
         <h4>Security options:</h4>
         <!-- Note: security options are usually always key-value pairs, with so far a single exception: the
         'no-new-privileges' flag for the Linux daemon. It is therefore handled as list of strings instead of a


### PR DESCRIPTION
Add additional groups to run as.  
Equivalent to the `--group-add` CLI flag.